### PR TITLE
Add Items tab + Fix MaxDecimalPlaces on NumberField

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,14 @@ plugins {
 }
 
 ext {
-    // Override: use C:/Games/Hytale instead of default AppData location
-    hytaleHome = "C:/Games/Hytale"
+    def userHome = System.getProperty("user.home")
+    def os = System.getProperty("os.name").toLowerCase()
+    if (os.contains("win")) {
+        hytaleHome = "${userHome}/AppData/Roaming/Hytale"
+    } else {
+        // Assume we are on Linux, we love Linux flatpaks here.
+        hytaleHome = "${userHome}/.var/app/com.hypixel.HytaleLauncher/data/Hytale"
+    }
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ includes_pack=true
 maven_group=au.ellie
 
 java_version=25
-patchline=release
+patchline=pre-release
 
 # Determines if the development server should also load mods from the user's
 # standard mods folder. This lets you test mods by installing them where a


### PR DESCRIPTION
## Summary

### 1. Items tab for Showcase
- Adds new "Items" tab demonstrating ItemSlot and ItemGrid elements

### 2. NumberField Format - Cannot be set dynamically

Tested and confirmed: `Format` property **cannot** be set via `commands.set()`.

Hytale expects `NumberFieldFormat` type, not a String. Setting it causes:
```
Failed to convert JSON value (String) to specified type (NumberFieldFormat)
```

This means `data-hyui-max-decimal-places` cannot work. Users must define Format inline in `.ui` template files:
```
$C.@NumberField #MyNumberField {
    Value: 0;
    Format: (MaxDecimalPlaces:2,Step:0.5);
}
```

Reference: https://github.com/underscore95/hytale-ui-docs/blob/main/docs/UIElements/-C--NumberField.md

**Changes:**
- Added comment explaining the limitation in `NumberFieldBuilder.java`
- Removed non-functional `data-hyui-max-decimal-places` implementation

## Test plan
- Run `/showcase` (requires `LOGGING_ENABLED = true`)
- Verify Items tab shows ItemSlot and ItemGrid correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)