### PR TITLE
v0.9.7 - Fix Hytale 0.5.1 HUD compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.9.6
+version=0.9.7
 website=ellie.au
 author_name=Ellie
 includes_pack=true

--- a/src/main/java/au/ellie/hyui/builders/HyUIHud.java
+++ b/src/main/java/au/ellie/hyui/builders/HyUIHud.java
@@ -64,7 +64,7 @@ public class HyUIHud extends CustomUIHud implements UIContext {
                    TemplateProcessor templateProcessor,
                    boolean runtimeTemplateUpdatesEnabled,
                    InterfaceBuilder<?> rootElementBuilder) {
-        super(playerRef);
+        super(playerRef, name);
         this.name = name;
         this.delegate = new HyUInterface(uiFile, elements, editCallbacks, templateHtml, templateProcessor, runtimeTemplateUpdatesEnabled, rootElementBuilder) {};
     }

--- a/src/main/java/au/ellie/hyui/utils/MultiHudWrapper.java
+++ b/src/main/java/au/ellie/hyui/utils/MultiHudWrapper.java
@@ -29,6 +29,7 @@ import com.hypixel.hytale.server.core.plugin.PluginManager;
 import com.hypixel.hytale.server.core.universe.PlayerRef;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
+import au.ellie.hyui.utils.multiplehud.MultipleHUD;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -99,7 +100,7 @@ public class MultiHudWrapper {
     public static List<HyUIHud> getHuds(Player player, PlayerRef playerRef) {
         List<HyUIHud> huds = new ArrayList<>();
         if (!useOwnMHUD) {
-            CustomUIHud currentHud = player.getHudManager().getCustomHud();
+            CustomUIHud currentHud = player.getHudManager().getCustomHud(MultipleHUD.HUD_KEY);
             if (currentHud != null && currentHud.getClass().getName().endsWith("MultipleCustomUIHud")) {
                 try {
                     java.lang.reflect.Field customHudsField = currentHud.getClass().getDeclaredField("customHuds");

--- a/src/main/java/au/ellie/hyui/utils/multiplehud/MultipleCustomUIHud.java
+++ b/src/main/java/au/ellie/hyui/utils/multiplehud/MultipleCustomUIHud.java
@@ -147,7 +147,7 @@ public class MultipleCustomUIHud extends CustomUIHud {
     private final HashMap<String, CustomUIHud> customHuds = new HashMap<>();
 
     public MultipleCustomUIHud(@NonNullDecl PlayerRef playerRef) {
-        super(playerRef);
+        super(playerRef, MultipleHUD.HUD_KEY);
     }
 
     @Override

--- a/src/main/java/au/ellie/hyui/utils/multiplehud/MultipleHUD.java
+++ b/src/main/java/au/ellie/hyui/utils/multiplehud/MultipleHUD.java
@@ -37,6 +37,9 @@ SOFTWARE.
  */
 public class MultipleHUD {
 
+    // HUD key for HyUI's internal multi-HUD container.
+    public static final String HUD_KEY = "HyUI:MultipleHUD";
+
     private static MultipleHUD instance;
 
     public static MultipleHUD getInstance() {
@@ -56,16 +59,13 @@ public class MultipleHUD {
 
 
     public void setCustomHud(Player player, PlayerRef playerRef, String hudIdentifier, CustomUIHud customHud) {
-        CustomUIHud currentCustomHud = player.getHudManager().getCustomHud();
+        CustomUIHud currentCustomHud = player.getHudManager().getCustomHud(HUD_KEY);
         if (currentCustomHud instanceof MultipleCustomUIHud multipleCustomUIHud) {
             multipleCustomUIHud.add(hudIdentifier, customHud);
         } else {
             MultipleCustomUIHud mchud = new MultipleCustomUIHud(playerRef);
-            player.getHudManager().setCustomHud(playerRef, mchud);
+            player.getHudManager().addCustomHud(playerRef, mchud);
             mchud.add(hudIdentifier, customHud);
-            if (currentCustomHud != null) {
-                mchud.add("Unknown", currentCustomHud);
-            }
         }
     }
 
@@ -74,7 +74,7 @@ public class MultipleHUD {
         hideCustomHud(player, hudIdentifier);
     }
     public void hideCustomHud(Player player, String hudIdentifier) {
-        var currentCustomHud = player.getHudManager().getCustomHud();
+        var currentCustomHud = player.getHudManager().getCustomHud(HUD_KEY);
 
         if (currentCustomHud instanceof MultipleCustomUIHud multipleCustomUIHud) {
             multipleCustomUIHud.remove(hudIdentifier);
@@ -82,7 +82,7 @@ public class MultipleHUD {
     }
     
     public HashMap<String, CustomUIHud> getCustomHuds(Player player) {
-        var currentCustomHud = player.getHudManager().getCustomHud();
+        var currentCustomHud = player.getHudManager().getCustomHud(HUD_KEY);
 
         if (currentCustomHud instanceof MultipleCustomUIHud multipleCustomUIHud) {
             return multipleCustomUIHud.getCustomHuds();

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -1,7 +1,7 @@
 {
     "Group": "Ellie",
     "Name": "HyUI",
-    "Version": "0.9.6",
+    "Version": "0.9.7",
     "Description": "A library for mods that helps build GUIs faster and better.",
     "Authors": [
         {


### PR DESCRIPTION
# v0.9.7 - Fix Hytale 0.5.1 HUD compatibility

## Summary

This updates HyUI's custom HUD handling for the Hytale 0.5.1 HUD API.

Hytale's custom HUD API now identifies custom HUDs by key. `CustomUIHud` no longer exposes the old `CustomUIHud(PlayerRef)` constructor, and `HudManager` now exposes keyed custom HUD methods such as `getCustomHud(String)` and `addCustomHud(PlayerRef, CustomUIHud)`.

## Runtime issue

The issue appeared when a plugin using HyUI attempted to show or refresh a HUD. The server world crashed and disconnected the player.

Observed server log excerpt:

```text
[2026/05/26 20:56:03   INFO] [CommandManager] Janiel778 executed command: nexorimenu
[2026/05/26 20:56:11 SEVERE] [Hytale] Exception in thread Thread[#103,WorldThread - Forgotten_Temple,5,InnocuousForkJoinWorkerThreadGroup] potentially caused by Ellie:HyUI:
java.lang.NoSuchMethodError: 'void com.hypixel.hytale.server.core.entity.entities.player.hud.CustomUIHud.<init>(com.hypixel.hytale.server.core.universe.PlayerRef)'
    at ThirdParty(Ellie:HyUI)//au.ellie.hyui.builders.HyUIHud.<init>(HyUIHud.java:67)
    at ThirdParty(Ellie:HyUI)//au.ellie.hyui.builders.HudBuilder.show(HudBuilder.java:136)
    at ThirdParty(Nexori:NexoriPlugin)//io.github.hyjn.nexori.plugin.hud.NexoriStatusHudService.refresh(NexoriStatusHudService.java:110)
    at ThirdParty(Nexori:NexoriPlugin)//io.github.hyjn.nexori.plugin.hud.NexoriStatusHudService.handlePlayerTick(NexoriStatusHudService.java:61)
    at ThirdParty(Nexori:NexoriPlugin)//io.github.hyjn.nexori.plugin.hud.NexoriStatusHudTickSystem.tick(NexoriStatusHudTickSystem.java:42)
```

The disconnect message was:

```text
The world you were on has crashed (possibly caused by Ellie:HyUI)
```

## Cause

HyUI was compiled against an older Hytale HUD API where custom HUDs were effectively managed as a single active custom HUD per player.

The new API requires custom HUDs to have a stable key:

```java
CustomUIHud(PlayerRef, String)
CustomUIHud(PlayerRef, String, int)
```

`HudManager` also moved to keyed custom HUD methods:

```java
getCustomHud(String)
getCustomHuds()
addCustomHud(PlayerRef, CustomUIHud)
removeCustomHud(PlayerRef, String)
```

Because the old constructor no longer exists at runtime, HyUI failed with `NoSuchMethodError` when creating a `HyUIHud`.

## Fix

The fix keeps HyUI's existing multi-HUD behavior and adapts it to the keyed Hytale HUD API.

Changes:

- `HyUIHud` now passes its generated HUD name to `CustomUIHud`.
- `MultipleCustomUIHud` now has a stable container key.
- `MultipleHUD` now retrieves the internal HyUI multi-HUD container by key.
- `MultipleHUD` now registers the container with `addCustomHud(...)`.
- The internal HyUI container key is centralized as `MultipleHUD.HUD_KEY`.
- Version metadata is updated to `0.9.7`.

The individual HyUI HUD key is still generated by `HudBuilder`:

```java
String name = "HYUIHUD" + UUID.randomUUID().toString().replace("-", "");
```

That generated name is used as the key for each individual `HyUIHud`.

The internal HyUI multi-HUD container uses a stable key:

```java
HUD_KEY = "HyUI:MultipleHUD"
```

Conceptually:

```text
HudManager
  HyUI:MultipleHUD -> MultipleCustomUIHud
      HYUIHUD<uuid> -> HyUIHud
      HYUIHUD<uuid> -> HyUIHud
```

## Verification

Local build:

```text
./gradlew.bat clean releaseJar
```

Result:

```text
BUILD SUCCESSFUL
TemplateProcessorTest: 18 passed
```

Runtime smoke test:

- Server booted with `HyUI-0.9.7-all.jar`.
- Tested with a local mod that uses HyUI for HUDs and custom pages.
- The game no longer crashes when the mod renders a HyUI HUD.
- HUDs render normally.
- Custom pages open and render normally.
- UI interaction works normally.
