### PR TITLE
Fix HUD rerenders on Hytale 0.5.1

### DIFF
--- a/src/main/java/au/ellie/hyui/builders/HyUIHud.java
+++ b/src/main/java/au/ellie/hyui/builders/HyUIHud.java
@@ -300,12 +300,9 @@ public class HyUIHud extends CustomUIHud implements UIContext {
         } else {
             // Re-render completely.
             if (!unsafe) {
-                this.safeAdd();
+                this.safeFullRerender();
             } else {
-                var player = getPlayer();
-                if (player == null) return;
-
-                MultiHudWrapper.setCustomHud(player, getPlayerRef(), this.name, this);
+                this.fullRerender();
             }
 
         }
@@ -367,6 +364,19 @@ public class HyUIHud extends CustomUIHud implements UIContext {
 
             MultiHudWrapper.setCustomHud(player, getPlayerRef(), this.name, this);
         });
+    }
+
+    private void safeFullRerender() {
+        var store = getStore();
+        if (store == null) return;
+
+        store.getExternalData().getWorld().execute(this::fullRerender);
+    }
+
+    private void fullRerender() {
+        UICommandBuilder uiCommandBuilder = new UICommandBuilder();
+        delegate.buildFromCommandBuilder(uiCommandBuilder, false, new UIEventBuilder());
+        this.update(true, uiCommandBuilder);
     }
 
     private Store<EntityStore> getStore() {


### PR DESCRIPTION
# HyUI 0.9.7 - Hytale 0.5.1 HUD rerender follow-up

While testing `v0.9.7 - Complete Build Change, 0.5.1 support?` against Hytale 0.5.1, I found one remaining HUD-specific runtime issue.

The original `CustomUIHud(PlayerRef)` crash is fixed by the 0.5.1 changes, and custom pages still render and interact correctly.

The remaining issue is that custom HUDs render their first frame, but later updates do not visually refresh on the client.

## Runtime comparison

### Before this fix

The HUD is created and the first frame is visible, but the countdown/progress text stays frozen. The game logic continues running server-side.

<img width="800" height="450" alt="Before fix: HUD renders initial frame but does not update" src="https://github.com/user-attachments/assets/0ad3965d-ae9d-4abc-a6c8-a1099b5054c4" />

### After this fix

With commit `1cc546b`, the same HUD flow refreshes normally after the initial render.

<img width="800" height="450" alt="After fix: HUD updates correctly" src="https://github.com/user-attachments/assets/af0a8efb-4c8d-46bb-9967-cdb8712966cd" />

## What caused it

This seems to come from the new native `HudManager` behavior in Hytale 0.5.1.

The new API stores custom HUDs by key. In `HudManager.addCustomHud(...)`, if the HUD currently registered for that key is the same object instance, the method returns early.

So the flow became:

```text
HyUIHud.update(builder)
  -> refreshOrRerender(true, false)
  -> MultiHudWrapper.setCustomHud(player, playerRef, name, this)
  -> HudManager.addCustomHud(playerRef, this)
  -> same key + same HyUIHud instance
  -> early return, no new CustomHud packet sent
```

That means the first render works, but later full rerenders can be skipped before any updated HUD commands reach the client.

Fixes #39
