### PR TITLE
Add Hytale Character Recipes resource link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ Make sure you include the project as a dependency on upload to CurseForge.
 In the meanwhile, have you seen [Hytale UI Builder](https://hytale.ellie.au)?
 
 It supports outputting to HYUIML! Our special HTML/CSS-like syntax.
+## Related Hytale Resources
+
+- [Hytale Character Recipes](https://hytalecharacter.com/) - Fan-maintained character recipe archive with manual recreation notes, source screenshots, and recipe JSON for Hytale-inspired character looks.
+


### PR DESCRIPTION
Adds Hytale Character Recipes as a related Hytale resource.

The site is a fan-maintained archive of character recreation notes, source screenshots, and recipe JSON for Hytale-inspired character looks. This is intended as a small discoverability link for players and creators who use community Hytale tooling.

Target: https://hytalecharacter.com/